### PR TITLE
Test against Python 3.6 and 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: python
 sudo: false
-python:
-  - 2.7
-  - 3.4
-  - 3.5
+language: python
+matrix:
+  - python: '2.7'
+  - python: '3.5'
+  - python: '3.6'
+  - python: '3.7'
+    dist: xenial
 env:
   - CONFIG=buildout.cfg
 install:

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,9 @@ Programming Language :: Python
 Programming Language :: Python :: 2
 Programming Language :: Python :: 2.7
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.4
 Programming Language :: Python :: 3.5
+Programming Language :: Python :: 3.6
+Programming Language :: Python :: 3.7
 Programming Language :: Python :: Implementation :: CPython
 Topic :: Database
 Topic :: Software Development :: Libraries :: Python Modules


### PR DESCRIPTION
Updated the trove classifiers accordingly.

I removed testing against 3.4 because it is probably not needed anymore as long as it works with all the others 3.x branches.