### PR TITLE
Fine tune versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: ${{ matrix.config[1] }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.config[0] }}
     - name: Install dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ jobs:
       matrix:
         config:
         # [Python version, tox env]
-        - ["3.6",   "py36"]
         - ["3.7",   "py37"]
         - ["3.8",   "py38"]
         - ["3.9",   "py39"]

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ For earlier changes, see the `HISTORY.rst <HISTORY.rst>`_.
 
 - Drop support for Python 2.7
 
-- Drop support for Python 3.4 and Python 3.5.
+- Drop support for Python 3.4, 3.5 and 3.6.
 
 
 3.1.0 (2017-04-07)

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,6 @@ License :: OSI Approved :: Zope Public License
 Programming Language :: Python
 Programming Language :: Python :: 3
 Programming Language :: Python :: 3 :: Only
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ setup(
     entry_points = entry_points,
     package_dir = {'':'src'},
     namespace_packages = ['zc'],
-    install_requires = ['setuptools', 'six', 'Twisted', 'ZODB >=5.6.0'],
+    install_requires = ['setuptools', 'six', 'Twisted', 'ZODB ==5.6.0'],
     extras_require = dict(test=tests_require),
     tests_require = tests_require,
     test_suite = 'zc.zrstests.tests.test_suite',

--- a/src/zc/zrs/tests.py
+++ b/src/zc/zrs/tests.py
@@ -1567,6 +1567,7 @@ class ZEOTests(ZEO.tests.testZEO.FullGenericTests):
             except Exception:
                 # Hm. Maybe we didn't wait long enough before starting
                 # the compare.  Let's wait a tad longer.
+                print(f'it failed, retrying {i}')
                 if i == 999:
                     raise
                 time.sleep(.1)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 envlist =
-    py36
     py37
     py38
     py39
@@ -21,7 +20,6 @@ setenv =
 [testenv:coverage-report]
 basepython = python3
 depends =
-    py36
     py37
     py38
     py39


### PR DESCRIPTION
- drop python 3.6
- force ZODB 5.6.0

On #11 this combination enabled the test suite to pass 🍀 🤞🏾 
